### PR TITLE
Deprecate use all collateral price ids and fetch pyth prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,13 @@ and all transactions will be automatically signed, without any popups
     # check your balance
     cast balance 0xWalletAddress -e
     ```
+
+8.  Periodically (once an hour or less) sync fork time and update prices.
+
+    ```sh
+    yarn update-prices:arbitrum
+    yarn sync-time
+    ```
+
+    Because price updates are coming from offchain server we need to bring fork's internal time to realtime,
+    otherwise we will will have empty `priceUpdateTx` but then consistently get `OracleDataRequiredError` for ALL price feeds

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -4,15 +4,6 @@
   "version": "0.0.0",
   "main": "index.js",
   "types": "index.d.ts",
-  "scripts": {
-    "start:mainnet": "anvil --chain-id 1 --fork-url https://mainnet.infura.io/v3/$INFURA_KEY",
-    "start:sepolia": "anvil --chain-id 11155111 --fork-url https://sepolia.infura.io/v3/$INFURA_KEY",
-    "start:optimism": "anvil --chain-id 10 --fork-url https://optimism.infura.io/v3/$INFURA_KEY",
-    "start:base": "anvil --chain-id 8453 --fork-url https://base-mainnet.infura.io/v3/$INFURA_KEY",
-    "start:base-sepolia": "anvil --chain-id 84532 --fork-url https://base-sepolia.infura.io/v3/$INFURA_KEY",
-    "start:arbitrum": "anvil --chain-id 42161 --fork-url https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY",
-    "start:arbitrum-sepolia": "anvil --chain-id 421614 --fork-url https://arbitrum-sepolia.infura.io/v3/$INFURA_KEY"
-  },
   "dependencies": {
     "@synthetixio/v3-contracts": "^6.10.0",
     "viem": "^2.13.5"

--- a/liquidity/cypress/bin/approveCollateral.ts
+++ b/liquidity/cypress/bin/approveCollateral.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env ts-node
 
-// @ts-ignore
 import { approveCollateral } from '../cypress/tasks/approveCollateral';
 const [privateKey, symbol] = process.argv.slice(2);
 if (!privateKey || !symbol) {

--- a/liquidity/cypress/bin/createAccount.ts
+++ b/liquidity/cypress/bin/createAccount.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env ts-node
 
-// @ts-ignore
 import { createAccount } from '../cypress/tasks/createAccount';
 const [privateKey] = process.argv.slice(2);
 if (!privateKey) {

--- a/liquidity/cypress/bin/getSnx.ts
+++ b/liquidity/cypress/bin/getSnx.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env ts-node
 
-// @ts-ignore
 import { getSnx } from '../cypress/tasks/getSnx';
 const [address, amount] = process.argv.slice(2);
 if (!address || !amount) {

--- a/liquidity/cypress/bin/setEthBalance.ts
+++ b/liquidity/cypress/bin/setEthBalance.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env ts-node
 
-// @ts-ignore
 import { setEthBalance } from '../cypress/tasks/setEthBalance';
 const [address, balance] = process.argv.slice(2);
 if (!address || !balance) {

--- a/liquidity/cypress/bin/syncTime.ts
+++ b/liquidity/cypress/bin/syncTime.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env ts-node
+
+import { syncTime } from '../cypress/tasks/syncTime';
+syncTime();

--- a/liquidity/cypress/cypress/tasks/doAllPriceUpdates.js
+++ b/liquidity/cypress/cypress/tasks/doAllPriceUpdates.js
@@ -22,7 +22,7 @@ export async function doAllPriceUpdates({ privateKey }) {
     )
     .map(([_key, value]) => value);
   console.log({ feedIds });
-  const batches = splitIntoChunks(feedIds, 50);
+  const batches = splitIntoChunks(feedIds, 20);
 
   for (const batch of batches) {
     console.log({ batch });

--- a/liquidity/cypress/cypress/tasks/syncTime.js
+++ b/liquidity/cypress/cypress/tasks/syncTime.js
@@ -1,0 +1,57 @@
+import { ethers } from 'ethers';
+
+export async function wait(ms) {
+  return new Promise((resolve) => {
+    console.log('syncTime', 'Wait', { ms });
+    setTimeout(() => {
+      console.log('syncTime', 'Done waiting', { ms });
+      resolve();
+    }, ms);
+  });
+}
+
+export async function getTimes(provider) {
+  const blockNumber = await provider.send('eth_blockNumber', []);
+  const block = await provider.send('eth_getBlockByNumber', [blockNumber, false]);
+  const blockTimestamp = parseInt(block.timestamp, 16);
+  const now = Math.floor(Date.now() / 1000);
+  return { blockNumber, blockTimestamp, now };
+}
+
+export async function syncTime() {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+
+  const oldTimes = await getTimes(provider);
+  console.log('syncTime', {
+    diff: oldTimes.now - oldTimes.blockTimestamp,
+    oldRealtime: new Date(oldTimes.now * 1000),
+    oldBlockNumber: oldTimes.blockNumber,
+    oldBlockTimestamp: new Date(oldTimes.blockTimestamp * 1000),
+  });
+
+  if (oldTimes.blockTimestamp === oldTimes.now) {
+    console.log('syncTime', 'SKIP');
+    return;
+  }
+
+  if (oldTimes.blockTimestamp < oldTimes.now) {
+    // We restored from snapshot, or working with an old fork, so block timestamp is out of date
+    await provider.send('anvil_setTime', [oldTimes.now - 1]);
+    await provider.send('evm_mine', []);
+  }
+
+  if (oldTimes.blockTimestamp > oldTimes.now) {
+    await provider.send('anvil_setTime', [oldTimes.now - 1]);
+    await provider.send('evm_mine', []);
+  }
+
+  const newTimes = await getTimes(provider);
+  console.log('syncTime', {
+    diff: newTimes.now - newTimes.blockTimestamp,
+    newRealtime: new Date(newTimes.now * 1000),
+    newBlockNumber: newTimes.blockNumber,
+    newBlockTimestamp: new Date(newTimes.blockTimestamp * 1000),
+  });
+}

--- a/liquidity/cypress/package.json
+++ b/liquidity/cypress/package.json
@@ -10,6 +10,7 @@
     "cy": "NODE_ENV=test cypress open --component --browser chrome",
     "e2e:arbitrum": "NODE_ENV=test CYPRESS_CHAIN_ID=42161 CYPRESS_PRESET=main cypress open --e2e --browser chrome --config specPattern='./cypress/e2e/42161-main/*.e2e.js'",
     "e2e:base": "NODE_ENV=test CYPRESS_CHAIN_ID=8453 CYPRESS_PRESET=andromeda cypress open --e2e --browser chrome --config specPattern='./cypress/e2e/8453-andromeda/*.e2e.js'",
+    "sync-time": "ts-node bin/syncTime.ts",
     "update-prices": "ts-node bin/doAllPriceUpdates.ts 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     "update-prices:arbitrum": "NODE_ENV=test CYPRESS_CHAIN_ID=42161 CYPRESS_PRESET=main yarn update-prices",
     "update-prices:base": "NODE_ENV=test CYPRESS_CHAIN_ID=8453 CYPRESS_PRESET=andromeda yarn update-prices"

--- a/liquidity/cypress/package.json
+++ b/liquidity/cypress/package.json
@@ -4,9 +4,9 @@
   "main": "index.ts",
   "version": "0.0.9",
   "scripts": {
-    "anvil:arbitrum": "anvil --auto-impersonate --chain-id 42161 --fork-url https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY",
-    "anvil:sepolia": "anvil --auto-impersonate --chain-id 11155111 --fork-url https://sepolia.infura.io/v3/$INFURA_KEY",
-    "anvil:base": "anvil --auto-impersonate --chain-id 8453 --fork-url https://base-mainnet.infura.io/v3/$INFURA_KEY",
+    "anvil:arbitrum": "anvil --auto-impersonate --chain-id 42161 --fork-url https://arbitrum-mainnet.infura.io/v3/$INFURA_KEY --timeout 5000 --retries 0 --no-rate-limit --steps-tracing",
+    "anvil:sepolia": "anvil --auto-impersonate --chain-id 11155111 --fork-url https://sepolia.infura.io/v3/$INFURA_KEY --timeout 5000 --retries 0 --no-rate-limit --steps-tracing",
+    "anvil:base": "anvil --auto-impersonate --chain-id 8453 --fork-url https://base-mainnet.infura.io/v3/$INFURA_KEY --timeout 5000 --retries 0 --no-rate-limit --steps-tracing",
     "cy": "NODE_ENV=test cypress open --component --browser chrome",
     "e2e:arbitrum": "NODE_ENV=test CYPRESS_CHAIN_ID=42161 CYPRESS_PRESET=main cypress open --e2e --browser chrome --config specPattern='./cypress/e2e/42161-main/*.e2e.js'",
     "e2e:base": "NODE_ENV=test CYPRESS_CHAIN_ID=8453 CYPRESS_PRESET=andromeda cypress open --e2e --browser chrome --config specPattern='./cypress/e2e/8453-andromeda/*.e2e.js'",

--- a/liquidity/lib/fetchPythPrices/fetchPythPrices.ts
+++ b/liquidity/lib/fetchPythPrices/fetchPythPrices.ts
@@ -1,8 +1,16 @@
-import { offchainMainnetEndpoint, offchainTestnetEndpoint } from '@snx-v3/constants';
 import { EvmPriceServiceConnection } from '@pythnetwork/pyth-evm-js';
-import { ethers, PopulatedTransaction, BigNumber } from 'ethers';
+import { offchainMainnetEndpoint, offchainTestnetEndpoint } from '@snx-v3/constants';
 import { Wei } from '@synthetixio/wei';
+import { BigNumber, ethers, PopulatedTransaction } from 'ethers';
 
+/**
+ * Fetches price updates from the price service based on the requested price updates.
+ * @deprecated This should not be used anywhere
+ *
+ * @param {Array} requestedPriceUpdates - The array of requested price updates.
+ * @param {boolean} isTestnet - Specifies whether the fetch is for testnet or mainnet.
+ * @returns {Promise<Array>} - The promise that resolves to an array of encoded price updates.
+ */
 export const fetchPriceUpdates = async (
   requestedPriceUpdates: { priceFeedId: string; stalenessTolerance: Wei }[],
   isTestnet: boolean
@@ -26,6 +34,16 @@ export const fetchPriceUpdates = async (
   });
 };
 
+/**
+ * Generates an array of PopulatedTransaction objects based on the given inputs.
+ * @deprecated This should not be used anywhere
+ *
+ * @param {string} from - The address from which the transactions will be initiated.
+ * @param {Object[]} oracleAddresses - An array of objects with an "address" property representing the oracle addresses.
+ * @param {string[]} signedOffchainData - An array of signed offchain data for each oracle address.
+ * @throws {Error} If the length of oracleAddresses and signedOffchainData arrays is not the same.
+ * @returns {Object[]} An array of PopulatedTransaction objects.
+ */
 export const priceUpdatesToPopulatedTx = (
   from: string,
   oracleAddresses: { address: string }[],

--- a/liquidity/lib/useAllCollateralPriceIds/useAllCollateralPriceIds.ts
+++ b/liquidity/lib/useAllCollateralPriceIds/useAllCollateralPriceIds.ts
@@ -1,7 +1,7 @@
 import { deploymentHasERC7412, Network, useNetwork } from '@snx-v3/useBlockchain';
+import { useCollateralTypes } from '@snx-v3/useCollateralTypes';
 import { useCoreProxy } from '@snx-v3/useCoreProxy';
 import { useMulticall3 } from '@snx-v3/useMulticall3';
-import { useCollateralTypes } from '@snx-v3/useCollateralTypes';
 import { useOracleManagerProxy } from '@snx-v3/useOracleManagerProxy';
 import { ZodBigNumber } from '@snx-v3/zod';
 import { wei } from '@synthetixio/wei';
@@ -21,8 +21,16 @@ const PythParametersSchema = z.object({
   stalenessTolerance: ZodBigNumber.transform((x) => wei(x)),
 });
 
-const EXTERNAL_NODE_TYPE = 2;
+const PYTH_NODE = 5;
 
+/**
+ * Fetches all collateral price ids
+ * @deprecated This should not be used anywhere
+ *
+ *
+ * @param {Network} [customNetwork] - Custom network object.
+ * @returns {QueryResult<Array<CollateralPriceId>>} The result of the query.
+ */
 export const useAllCollateralPriceIds = (customNetwork?: Network) => {
   const { network } = useNetwork();
   const targetNetwork = customNetwork || network;
@@ -38,7 +46,7 @@ export const useAllCollateralPriceIds = (customNetwork?: Network) => {
         Multicall3 &&
         OracleProxy &&
         CoreProxy &&
-        !!collateralConfigs?.length
+        collateralConfigs?.length
     ),
     staleTime: Infinity,
     queryKey: [`${targetNetwork?.id}-${targetNetwork?.preset}`, 'AllCollateralPriceIds'],
@@ -79,7 +87,7 @@ export const useAllCollateralPriceIds = (customNetwork?: Network) => {
 
           const { nodeType, parameters } = NodeSchema.parse({ ...nodeResp });
 
-          if (nodeType !== EXTERNAL_NODE_TYPE) return undefined;
+          if (nodeType !== PYTH_NODE) return undefined;
 
           try {
             const [address, priceFeedId, stalenessTolerance] = ethers.utils.defaultAbiCoder.decode(

--- a/liquidity/lib/useClaimUnwrapRewards/package.json
+++ b/liquidity/lib/useClaimUnwrapRewards/package.json
@@ -14,6 +14,7 @@
     "@snx-v3/useGasPrice": "workspace:*",
     "@snx-v3/useGasSpeed": "workspace:*",
     "@snx-v3/useSpotMarketProxy": "workspace:*",
+    "@snx-v3/useSynthTokens": "workspace:*",
     "@snx-v3/withERC7412": "workspace:*",
     "@synthetixio/wei": "^2.74.4",
     "@tanstack/react-query": "^5.8.3",

--- a/liquidity/lib/useClaimUnwrapRewards/package.json
+++ b/liquidity/lib/useClaimUnwrapRewards/package.json
@@ -5,11 +5,9 @@
   "version": "0.0.2",
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",
-    "@snx-v3/fetchPythPrices": "workspace:*",
-    "@snx-v3/tsHelpers": "workspace:*",
     "@snx-v3/txnReducer": "workspace:*",
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
+    "@snx-v3/useCollateralPriceUpdates": "workspace:*",
     "@snx-v3/useContractErrorParser": "workspace:*",
     "@snx-v3/useCoreProxy": "workspace:*",
     "@snx-v3/useGasOptions": "workspace:*",

--- a/liquidity/lib/useClaimUnwrapRewards/useClaimUnwrapRewards.ts
+++ b/liquidity/lib/useClaimUnwrapRewards/useClaimUnwrapRewards.ts
@@ -8,12 +8,12 @@ import { formatGasPriceForTransaction } from '@snx-v3/useGasOptions';
 import { getGasPrice } from '@snx-v3/useGasPrice';
 import { useGasSpeed } from '@snx-v3/useGasSpeed';
 import { useSpotMarketProxy } from '@snx-v3/useSpotMarketProxy';
+import { useSynthTokens } from '@snx-v3/useSynthTokens';
 import { withERC7412 } from '@snx-v3/withERC7412';
 import Wei from '@synthetixio/wei';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { BigNumber } from 'ethers';
 import { useReducer } from 'react';
-import { useSynthTokens } from '../useSynthTokens';
 
 export function useClaimUnwrapRewards({
   poolId,

--- a/liquidity/lib/useClaimUnwrapRewards/useClaimUnwrapRewards.ts
+++ b/liquidity/lib/useClaimUnwrapRewards/useClaimUnwrapRewards.ts
@@ -1,22 +1,19 @@
-import { useReducer } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { BigNumber } from 'ethers';
-import { useCoreProxy } from '@snx-v3/useCoreProxy';
+import { useToast } from '@chakra-ui/react';
 import { initialState, reducer } from '@snx-v3/txnReducer';
 import { useNetwork, useProvider, useSigner } from '@snx-v3/useBlockchain';
-
-import { useToast } from '@chakra-ui/react';
-import { useSpotMarketProxy } from '@snx-v3/useSpotMarketProxy';
-import { fetchPriceUpdates, priceUpdatesToPopulatedTx } from '@snx-v3/fetchPythPrices';
-import { useAllCollateralPriceIds } from '@snx-v3/useAllCollateralPriceIds';
-import { getGasPrice } from '@snx-v3/useGasPrice';
-import { withERC7412 } from '@snx-v3/withERC7412';
-import { formatGasPriceForTransaction } from '@snx-v3/useGasOptions';
-import { useGasSpeed } from '@snx-v3/useGasSpeed';
-import { notNil } from '@snx-v3/tsHelpers';
-import Wei from '@synthetixio/wei';
-import { useSynthTokens } from '../useSynthTokens';
+import { useCollateralPriceUpdates } from '@snx-v3/useCollateralPriceUpdates';
 import { useContractErrorParser } from '@snx-v3/useContractErrorParser';
+import { useCoreProxy } from '@snx-v3/useCoreProxy';
+import { formatGasPriceForTransaction } from '@snx-v3/useGasOptions';
+import { getGasPrice } from '@snx-v3/useGasPrice';
+import { useGasSpeed } from '@snx-v3/useGasSpeed';
+import { useSpotMarketProxy } from '@snx-v3/useSpotMarketProxy';
+import { withERC7412 } from '@snx-v3/withERC7412';
+import Wei from '@synthetixio/wei';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { BigNumber } from 'ethers';
+import { useReducer } from 'react';
+import { useSynthTokens } from '../useSynthTokens';
 
 export function useClaimUnwrapRewards({
   poolId,
@@ -41,7 +38,7 @@ export function useClaimUnwrapRewards({
   const { data: CoreProxy } = useCoreProxy();
   const [txnState, dispatch] = useReducer(reducer, initialState);
   const client = useQueryClient();
-  const { data: collateralPriceUpdates } = useAllCollateralPriceIds();
+  const { data: priceUpdateTx, refetch: refetchPriceUpdateTx } = useCollateralPriceUpdates();
   const provider = useProvider();
   const { gasSpeed } = useGasSpeed();
   const { data: synthTokens } = useSynthTokens();
@@ -50,61 +47,44 @@ export function useClaimUnwrapRewards({
   const mutation = useMutation({
     mutationFn: async function () {
       try {
-        if (!amount || !signer) return;
-        if (!poolId || !collateralAddress || !accountId || !distributorAddress || !network)
+        if (!(signer && network && provider)) throw new Error('No signer or network');
+        if (!amount) return;
+        if (!poolId || !collateralAddress || !accountId || !distributorAddress)
           throw new Error('Parameters Undefined');
         if (!CoreProxy) throw new Error('CoreProxy undefined');
+        if (!SpotProxy) throw new Error('SpotProxy undefined');
 
         dispatch({ type: 'prompting' });
 
-        const transcations = [];
-        transcations.push(
-          CoreProxy.populateTransaction.claimRewards(
-            BigNumber.from(accountId),
-            BigNumber.from(poolId),
-            collateralAddress,
-            distributorAddress
-          )
+        const claimRewardsPopulatedTxnPromise = CoreProxy.populateTransaction.claimRewards(
+          BigNumber.from(accountId),
+          BigNumber.from(poolId),
+          collateralAddress,
+          distributorAddress
         );
 
         const synthToken = synthTokens?.find(
           (synth) => synth.address.toUpperCase() === payoutTokenAddress?.toUpperCase()
         );
 
-        if (synthToken) {
-          transcations.push(
-            SpotProxy?.populateTransaction.unwrap(
+        const unwrapPopulatedTxnPromise = synthToken
+          ? SpotProxy.populateTransaction.unwrap(
               synthToken.synthMarketId,
               amount.toBN(),
               amount.toBN().mul(98).div(100).toNumber().toFixed()
             )
-          );
-        }
-
-        const callsPromise = Promise.all(transcations.filter(notNil));
+          : undefined;
 
         const walletAddress = await signer.getAddress();
-        const collateralPriceCallsPromise = fetchPriceUpdates(
-          collateralPriceUpdates,
-          network?.isTestnet
-        ).then((signedData) =>
-          priceUpdatesToPopulatedTx(walletAddress, collateralPriceUpdates, signedData)
-        );
-
-        const [calls, gasPrices, collateralPriceCalls] = await Promise.all([
-          callsPromise,
-          getGasPrice({ provider: provider! }),
-          collateralPriceCallsPromise,
+        const callsPromise = Promise.all([
+          claimRewardsPopulatedTxnPromise,
+          ...(unwrapPopulatedTxnPromise ? [unwrapPopulatedTxnPromise] : []),
         ]);
-
-        const allCalls = collateralPriceCalls.concat(calls);
-
-        const erc7412Tx = await withERC7412(
-          network,
-          allCalls,
-          'useClaimUnwrapRewards',
-          walletAddress
-        );
+        const [calls, gasPrices] = await Promise.all([callsPromise, getGasPrice({ provider })]);
+        if (priceUpdateTx) {
+          calls.push(priceUpdateTx as any);
+        }
+        const erc7412Tx = await withERC7412(network, calls, 'useClaimUnwrapRewards', walletAddress);
 
         const gasOptionsForTransaction = formatGasPriceForTransaction({
           gasLimit: erc7412Tx.gasLimit,
@@ -171,6 +151,10 @@ export function useClaimUnwrapRewards({
 
         return 0;
       }
+    },
+    onSuccess: () => {
+      // After mutation withERC7412, we guaranteed to have updated all the prices, dont care about await
+      refetchPriceUpdateTx();
     },
   });
 

--- a/liquidity/lib/useClearDebt/package.json
+++ b/liquidity/lib/useClearDebt/package.json
@@ -7,7 +7,6 @@
     "@snx-v3/isBaseAndromeda": "workspace:*",
     "@snx-v3/tsHelpers": "workspace:*",
     "@snx-v3/txnReducer": "workspace:*",
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useCollateralPriceUpdates": "workspace:*",
     "@snx-v3/useCoreProxy": "workspace:*",

--- a/liquidity/lib/useClearDebt/useClearDebt.tsx
+++ b/liquidity/lib/useClearDebt/useClearDebt.tsx
@@ -1,7 +1,6 @@
 import { getRepayerContract, USDC_BASE_MARKET } from '@snx-v3/isBaseAndromeda';
 import { notNil } from '@snx-v3/tsHelpers';
 import { initialState, reducer } from '@snx-v3/txnReducer';
-import { useAllCollateralPriceIds } from '@snx-v3/useAllCollateralPriceIds';
 import { useNetwork, useProvider, useSigner } from '@snx-v3/useBlockchain';
 import { useCollateralPriceUpdates } from '@snx-v3/useCollateralPriceUpdates';
 import { useCoreProxy } from '@snx-v3/useCoreProxy';
@@ -48,7 +47,6 @@ export const useClearDebt = ({
   const [txnState, dispatch] = useReducer(reducer, initialState);
   const { data: CoreProxy } = useCoreProxy();
   const { data: SpotMarketProxy } = useSpotMarketProxy();
-  const { data: collateralPriceIds } = useAllCollateralPriceIds();
   const { data: priceUpdateTx, refetch: refetchPriceUpdateTx } = useCollateralPriceUpdates();
 
   const signer = useSigner();
@@ -59,17 +57,7 @@ export const useClearDebt = ({
   const mutation = useMutation({
     mutationFn: async () => {
       if (!signer || !network || !provider) throw new Error('No signer or network');
-
-      if (
-        !(
-          CoreProxy &&
-          poolId &&
-          accountId &&
-          collateralTypeAddress &&
-          SpotMarketProxy &&
-          collateralPriceIds
-        )
-      ) {
+      if (!(CoreProxy && poolId && accountId && collateralTypeAddress && SpotMarketProxy)) {
         return;
       }
 

--- a/liquidity/lib/usePoolConfiguration/package.json
+++ b/liquidity/lib/usePoolConfiguration/package.json
@@ -4,8 +4,6 @@
   "main": "index.ts",
   "version": "0.0.2",
   "dependencies": {
-    "@snx-v3/fetchPythPrices": "workspace:*",
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useCollateralPriceUpdates": "workspace:*",
     "@snx-v3/useCoreProxy": "workspace:*",

--- a/liquidity/lib/useRewards/package.json
+++ b/liquidity/lib/useRewards/package.json
@@ -10,6 +10,7 @@
     "@snx-v3/useCoreProxy": "workspace:*",
     "@snx-v3/useMulticall3": "workspace:*",
     "@snx-v3/useRewardsDistributors": "workspace:*",
+    "@snx-v3/useSynthTokens": "workspace:*",
     "@synthetixio/wei": "^2.74.4",
     "@tanstack/react-query": "^5.8.3",
     "ethers": "^5.7.2",

--- a/liquidity/lib/useRewards/useRewards.ts
+++ b/liquidity/lib/useRewards/useRewards.ts
@@ -4,11 +4,11 @@ import { useCollateralType } from '@snx-v3/useCollateralTypes';
 import { useCoreProxy } from '@snx-v3/useCoreProxy';
 import { useMulticall3 } from '@snx-v3/useMulticall3';
 import { useRewardsDistributors } from '@snx-v3/useRewardsDistributors';
+import { useSynthTokens } from '@snx-v3/useSynthTokens';
 import { Wei, wei } from '@synthetixio/wei';
 import { useQuery } from '@tanstack/react-query';
 import { BigNumber } from 'ethers';
 import { z } from 'zod';
-import { useSynthTokens } from '../useSynthTokens';
 
 const RewardsResponseSchema = z.array(
   z.object({

--- a/liquidity/lib/useUndelegateBaseAndromeda/package.json
+++ b/liquidity/lib/useUndelegateBaseAndromeda/package.json
@@ -8,7 +8,6 @@
     "@snx-v3/isBaseAndromeda": "workspace:*",
     "@snx-v3/tsHelpers": "workspace:*",
     "@snx-v3/txnReducer": "workspace:*",
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*",
     "@snx-v3/useApprove": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useClearDebt": "workspace:*",

--- a/liquidity/lib/useUndelegateBaseAndromeda/useUndelegateBaseAndromeda.tsx
+++ b/liquidity/lib/useUndelegateBaseAndromeda/useUndelegateBaseAndromeda.tsx
@@ -2,7 +2,6 @@ import { parseUnits } from '@snx-v3/format';
 import { getRepayerContract, USDC_BASE_MARKET } from '@snx-v3/isBaseAndromeda';
 import { notNil } from '@snx-v3/tsHelpers';
 import { initialState, reducer } from '@snx-v3/txnReducer';
-import { useAllCollateralPriceIds } from '@snx-v3/useAllCollateralPriceIds';
 import { useApprove } from '@snx-v3/useApprove';
 import { useNetwork, useProvider, useSigner } from '@snx-v3/useBlockchain';
 import { DEBT_REPAYER_ABI } from '@snx-v3/useClearDebt';
@@ -43,7 +42,6 @@ export const useUndelegateBaseAndromeda = ({
   const signer = useSigner();
   const { gasSpeed } = useGasSpeed();
   const provider = useProvider();
-  const { data: collateralPriceUpdates } = useAllCollateralPriceIds();
   const { network } = useNetwork();
   const { data: usdTokens } = useGetUSDTokens();
 
@@ -60,10 +58,7 @@ export const useUndelegateBaseAndromeda = ({
   const mutation = useMutation({
     mutationFn: async () => {
       if (!signer || !network || !provider) throw new Error('No signer or network');
-      if (
-        !(CoreProxy && poolId && collateralTypeAddress && collateralPriceUpdates && SpotMarketProxy)
-      )
-        return;
+      if (!(CoreProxy && poolId && collateralTypeAddress && SpotMarketProxy)) return;
       if (collateralChange.eq(0)) return;
       if (currentCollateral.eq(0)) return;
       try {

--- a/liquidity/lib/useVaultsData/package.json
+++ b/liquidity/lib/useVaultsData/package.json
@@ -4,9 +4,7 @@
   "main": "index.ts",
   "version": "0.0.1",
   "dependencies": {
-    "@snx-v3/fetchPythPrices": "workspace:*",
     "@snx-v3/tsHelpers": "workspace:*",
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useCollateralPriceUpdates": "workspace:*",
     "@snx-v3/useCollateralTypes": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "yarn workspace @snx-v3/liquidity build",
     "update-prices:arbitrum": "yarn workspace @snx-v3/liquidity-cypress update-prices:arbitrum",
     "update-prices:base": "yarn workspace @snx-v3/liquidity-cypress update-prices:base",
+    "sync-time": "yarn workspace @snx-v3/liquidity-cypress sync-time",
     "anvil:arbitrum": "yarn workspace @snx-v3/liquidity-cypress anvil:arbitrum",
     "anvil:sepolia": "yarn workspace @snx-v3/liquidity-cypress anvil:sepolia",
     "anvil:base": "yarn workspace @snx-v3/liquidity-cypress anvil:base",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,7 +5051,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v3/fetchPythPrices@workspace:*, @snx-v3/fetchPythPrices@workspace:liquidity/lib/fetchPythPrices":
+"@snx-v3/fetchPythPrices@workspace:liquidity/lib/fetchPythPrices":
   version: 0.0.0-use.local
   resolution: "@snx-v3/fetchPythPrices@workspace:liquidity/lib/fetchPythPrices"
   dependencies:
@@ -5345,7 +5345,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v3/useAllCollateralPriceIds@workspace:*, @snx-v3/useAllCollateralPriceIds@workspace:liquidity/lib/useAllCollateralPriceIds":
+"@snx-v3/useAllCollateralPriceIds@workspace:liquidity/lib/useAllCollateralPriceIds":
   version: 0.0.0-use.local
   resolution: "@snx-v3/useAllCollateralPriceIds@workspace:liquidity/lib/useAllCollateralPriceIds"
   dependencies:
@@ -5494,11 +5494,9 @@ __metadata:
   resolution: "@snx-v3/useClaimUnwrapRewards@workspace:liquidity/lib/useClaimUnwrapRewards"
   dependencies:
     "@chakra-ui/react": "npm:^2.8.2"
-    "@snx-v3/fetchPythPrices": "workspace:*"
-    "@snx-v3/tsHelpers": "workspace:*"
     "@snx-v3/txnReducer": "workspace:*"
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
+    "@snx-v3/useCollateralPriceUpdates": "workspace:*"
     "@snx-v3/useContractErrorParser": "workspace:*"
     "@snx-v3/useCoreProxy": "workspace:*"
     "@snx-v3/useGasOptions": "workspace:*"
@@ -5520,7 +5518,6 @@ __metadata:
     "@snx-v3/isBaseAndromeda": "workspace:*"
     "@snx-v3/tsHelpers": "workspace:*"
     "@snx-v3/txnReducer": "workspace:*"
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useCollateralPriceUpdates": "workspace:*"
     "@snx-v3/useCoreProxy": "workspace:*"
@@ -5909,8 +5906,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@snx-v3/usePoolConfiguration@workspace:liquidity/lib/usePoolConfiguration"
   dependencies:
-    "@snx-v3/fetchPythPrices": "workspace:*"
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useCollateralPriceUpdates": "workspace:*"
     "@snx-v3/useCoreProxy": "workspace:*"
@@ -6197,7 +6192,6 @@ __metadata:
     "@snx-v3/isBaseAndromeda": "workspace:*"
     "@snx-v3/tsHelpers": "workspace:*"
     "@snx-v3/txnReducer": "workspace:*"
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*"
     "@snx-v3/useApprove": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useClearDebt": "workspace:*"
@@ -6258,9 +6252,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@snx-v3/useVaultsData@workspace:liquidity/lib/useVaultsData"
   dependencies:
-    "@snx-v3/fetchPythPrices": "workspace:*"
     "@snx-v3/tsHelpers": "workspace:*"
-    "@snx-v3/useAllCollateralPriceIds": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useCollateralPriceUpdates": "workspace:*"
     "@snx-v3/useCollateralTypes": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,6 +5503,7 @@ __metadata:
     "@snx-v3/useGasPrice": "workspace:*"
     "@snx-v3/useGasSpeed": "workspace:*"
     "@snx-v3/useSpotMarketProxy": "workspace:*"
+    "@snx-v3/useSynthTokens": "workspace:*"
     "@snx-v3/withERC7412": "workspace:*"
     "@synthetixio/wei": "npm:^2.74.4"
     "@tanstack/react-query": "npm:^5.8.3"
@@ -6028,6 +6029,7 @@ __metadata:
     "@snx-v3/useCoreProxy": "workspace:*"
     "@snx-v3/useMulticall3": "workspace:*"
     "@snx-v3/useRewardsDistributors": "workspace:*"
+    "@snx-v3/useSynthTokens": "workspace:*"
     "@synthetixio/wei": "npm:^2.74.4"
     "@tanstack/react-query": "npm:^5.8.3"
     ethers: "npm:^5.7.2"
@@ -6058,7 +6060,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@snx-v3/useSynthTokens@workspace:liquidity/lib/useSynthTokens":
+"@snx-v3/useSynthTokens@workspace:*, @snx-v3/useSynthTokens@workspace:liquidity/lib/useSynthTokens":
   version: 0.0.0-use.local
   resolution: "@snx-v3/useSynthTokens@workspace:liquidity/lib/useSynthTokens"
   dependencies:


### PR DESCRIPTION
- `useAllCollateralPriceIds` and `fetchPythPrices` were leftovers from initial implementation and are superseded by `priceUpdateTx`
- added `sync-time` command to bring fork's timestamp up to realtime
- adjust anvil runtime params to avoid it hanging or retrying on poor connections