### PR TITLE
Add support for pythFeeds.json

### DIFF
--- a/contracts/importers/importPythFeeds.js
+++ b/contracts/importers/importPythFeeds.js
@@ -1,0 +1,53 @@
+export async function importPythFeeds(chainId, preset) {
+  if (!preset) {
+    throw new Error(`Missing preset`);
+  }
+  const deployment = `${Number(chainId).toFixed(0)}-${preset}`;
+  switch (deployment) {
+    case '1-main': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/1-main/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '11155111-main': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/11155111-main/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '10-main': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/10-main/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '8453-andromeda': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/8453-andromeda/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '84532-andromeda': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/84532-andromeda/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '42161-main': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/42161-main/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    case '421614-main': {
+      const [{ default: pythFeeds }] = await Promise.all([
+        import('@synthetixio/v3-contracts/421614-main/pythFeeds.json'),
+      ]);
+      return pythFeeds;
+    }
+    default: {
+      throw new Error(`Unsupported deployment ${deployment} for pythFeeds`);
+    }
+  }
+}

--- a/contracts/index.d.ts
+++ b/contracts/index.d.ts
@@ -95,6 +95,12 @@ declare module '@snx-v3/contracts' {
       oracleNodeId: string;
       tokenAddress: string;
       minDelegationD18: string;
+      oracle: {
+        constPrice?: string;
+        externalContract?: string;
+        stalenessTolerance?: string;
+        pythFeedId?: string;
+      };
     }[]
   >;
 
@@ -151,4 +157,6 @@ declare module '@snx-v3/contracts' {
     chainId?: number,
     preset?: string
   ): Promise<{ address: string; abi: string[] }>;
+
+  function importPythFeeds(chainId?: number, preset?: string): Promise<string[]>;
 }

--- a/contracts/index.js
+++ b/contracts/index.js
@@ -24,3 +24,4 @@ export * from './importers/importStaticAaveUSDC';
 export * from './importers/importWETH';
 export * from './importers/importSNX';
 export * from './importers/importUSDC';
+export * from './importers/importPythFeeds';

--- a/liquidity/cypress/cypress/tasks/doAllPriceUpdates.js
+++ b/liquidity/cypress/cypress/tasks/doAllPriceUpdates.js
@@ -22,7 +22,7 @@ export async function doAllPriceUpdates({ privateKey }) {
     )
     .map(([_key, value]) => value);
   console.log({ feedIds });
-  const batches = splitIntoChunks(feedIds, 20);
+  const batches = splitIntoChunks(feedIds, 200);
 
   for (const batch of batches) {
     console.log({ batch });

--- a/liquidity/lib/useAccountCollateral/useAccountCollateral.ts
+++ b/liquidity/lib/useAccountCollateral/useAccountCollateral.ts
@@ -54,7 +54,7 @@ export const loadAccountCollateral = async ({
         totalLocked: wei(totalLocked),
         symbol: '',
         displaySymbol: '',
-        decimals: '',
+        decimals: 18,
       };
     });
   };
@@ -83,7 +83,10 @@ export function useAccountCollateral({
       'AccountCollateral',
       { accountId },
       { systemToken: systemToken?.address },
-      { priceUpdateTx: stringToHash(priceUpdateTx?.data) },
+      {
+        contracts: stringToHash([CoreProxy?.address].join()),
+        priceUpdateTx: stringToHash(priceUpdateTx?.data),
+      },
     ],
     enabled: Boolean(
       network &&
@@ -139,7 +142,7 @@ export function useAccountCollateral({
         return Object.assign(x, {
           symbol: collateralType?.symbol ?? '',
           displaySymbol: collateralType?.displaySymbol ?? '',
-          decimals: collateralType?.decimals ?? '18',
+          decimals: collateralType?.decimals ?? 18,
         });
       });
     },

--- a/liquidity/lib/useCollateralTypes/package.json
+++ b/liquidity/lib/useCollateralTypes/package.json
@@ -8,11 +8,9 @@
     "@snx-v3/isBaseAndromeda": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useSystemToken": "workspace:*",
-    "@snx-v3/zod": "workspace:*",
     "@synthetixio/wei": "^2.74.4",
     "@tanstack/react-query": "^5.8.3",
     "ethers": "^5.7.2",
-    "react": "^18.2.0",
-    "zod": "^3.22.4"
+    "react": "^18.2.0"
   }
 }

--- a/liquidity/lib/useLiquidityPosition/useLiquidityPosition.ts
+++ b/liquidity/lib/useLiquidityPosition/useLiquidityPosition.ts
@@ -11,7 +11,6 @@ import { ZodBigNumber } from '@snx-v3/zod';
 import Wei, { wei } from '@synthetixio/wei';
 import { useQuery } from '@tanstack/react-query';
 import { ethers } from 'ethers';
-import { useMemo } from 'react';
 import { z } from 'zod';
 
 const PositionCollateralSchema = z.object({
@@ -85,11 +84,6 @@ export const useLiquidityPosition = ({
   const provider = useProviderForChain(network!);
   const { data: collateralTypes } = useCollateralTypes(true);
 
-  const priceUpdateTxHash = useMemo(
-    () => (priceUpdateTx?.data ? stringToHash(priceUpdateTx?.data) : null),
-    [priceUpdateTx?.data]
-  );
-
   return useQuery({
     queryKey: [
       `${network?.id}-${network?.preset}`,
@@ -99,9 +93,11 @@ export const useLiquidityPosition = ({
         pool: poolId,
         token: tokenAddress,
         systemToken: systemToken?.address,
-        provider: !!provider,
       },
-      { priceUpdateTxHash },
+      {
+        contracts: stringToHash([CoreProxy?.address].join()),
+        priceUpdateTx: stringToHash(priceUpdateTx?.data),
+      },
     ],
     staleTime: 60000 * 5,
     enabled: Boolean(

--- a/liquidity/lib/usePythFeeds/index.ts
+++ b/liquidity/lib/usePythFeeds/index.ts
@@ -1,0 +1,1 @@
+export * from './usePythFeeds';

--- a/liquidity/lib/usePythFeeds/package.json
+++ b/liquidity/lib/usePythFeeds/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@snx-v3/usePythFeeds",
+  "private": true,
+  "main": "index.ts",
+  "version": "0.0.1",
+  "dependencies": {
+    "@snx-v3/contracts": "workspace:*",
+    "@snx-v3/useBlockchain": "workspace:*",
+    "@tanstack/react-query": "^5.8.3"
+  }
+}

--- a/liquidity/lib/usePythFeeds/usePythFeeds.ts
+++ b/liquidity/lib/usePythFeeds/usePythFeeds.ts
@@ -1,0 +1,20 @@
+import { importPythFeeds } from '@snx-v3/contracts';
+import { Network, useNetwork } from '@snx-v3/useBlockchain';
+import { useQuery } from '@tanstack/react-query';
+
+export function usePythFeeds(customNetwork?: Network) {
+  const { network } = useNetwork();
+  const targetNetwork = customNetwork || network;
+
+  return useQuery({
+    queryKey: [`${targetNetwork?.id}-${targetNetwork?.preset}`, 'PythFeeds'],
+    enabled: Boolean(targetNetwork),
+    queryFn: async function () {
+      if (!targetNetwork) {
+        throw new Error('OMFG');
+      }
+      return await importPythFeeds(targetNetwork.id, targetNetwork.preset);
+    },
+    staleTime: Infinity,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5583,12 +5583,10 @@ __metadata:
     "@snx-v3/isBaseAndromeda": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useSystemToken": "workspace:*"
-    "@snx-v3/zod": "workspace:*"
     "@synthetixio/wei": "npm:^2.74.4"
     "@tanstack/react-query": "npm:^5.8.3"
     ethers: "npm:^5.7.2"
     react: "npm:^18.2.0"
-    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 
@@ -5957,6 +5955,16 @@ __metadata:
     "@snx-v3/useBlockchain": "workspace:*"
     "@tanstack/react-query": "npm:^5.8.3"
     humanize-plus: "npm:^1.8.2"
+  languageName: unknown
+  linkType: soft
+
+"@snx-v3/usePythFeeds@workspace:liquidity/lib/usePythFeeds":
+  version: 0.0.0-use.local
+  resolution: "@snx-v3/usePythFeeds@workspace:liquidity/lib/usePythFeeds"
+  dependencies:
+    "@snx-v3/contracts": "workspace:*"
+    "@snx-v3/useBlockchain": "workspace:*"
+    "@tanstack/react-query": "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Additional changes (extracted from bigger refactor)
- `doAllPriceUpdates` should pdate all prices in one batch
- Separate `fetchOraclePrice` from `useOraclePrice`, fetcher can be used in non-react context to get the price
- Simplify `useCollateralTypes`: we no longer need zod validation because data is loaded from static json file, plus support all the fields from `collateralTypes.json`
