### PR TITLE
Accurate precision reduction

### DIFF
--- a/liquidity/lib/useDepositBaseAndromeda/useDepositBaseAndromeda.tsx
+++ b/liquidity/lib/useDepositBaseAndromeda/useDepositBaseAndromeda.tsx
@@ -108,18 +108,19 @@ export const useDepositBaseAndromeda = ({
         log('collateralChange', collateralChange);
         log('availableCollateral', availableCollateral);
 
-        const synthAmountNeeded = collateralChange.sub(availableCollateral);
+        const synthAmountNeeded = collateralChange
+          .sub(availableCollateral)
+          // Reduce precision to avoid rounding issues
+          .mul(ethers.utils.parseUnits('1', synth.token.decimals))
+          .div(D18)
+          // revert back to 18
+          .mul(D18)
+          .div(ethers.utils.parseUnits('1', synth.token.decimals));
         log('synthAmountNeeded', synthAmountNeeded);
 
         const tokenAmountToWrap = synthAmountNeeded
           .mul(ethers.utils.parseUnits('1', synth.token.decimals))
-          .div(D18)
-          // add one extra to cover precision difference
-          .add(
-            ethers.utils
-              .parseUnits('1', synth.token.decimals)
-              .div(ethers.utils.parseUnits('1', synth.token.decimals))
-          );
+          .div(D18);
         log('tokenAmountToWrap', tokenAmountToWrap);
 
         // Wrap


### PR DESCRIPTION
If we add one extra - we then trying transferring more than allowance and hitting `FailedTransfer` error (in some cases)

By reducing precision and then rasing it back to 18 we should eliminate this problem 