### PR TITLE
Fix rewards claiming cached state

### DIFF
--- a/liquidity/lib/useUnwrapAllSynths/package.json
+++ b/liquidity/lib/useUnwrapAllSynths/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",
     "@snx-v3/ContractError": "workspace:*",
+    "@snx-v3/constants": "workspace:*",
     "@snx-v3/txnReducer": "workspace:*",
     "@snx-v3/useBlockchain": "workspace:*",
     "@snx-v3/useCollateralPriceUpdates": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,6 +6296,7 @@ __metadata:
   dependencies:
     "@chakra-ui/react": "npm:^2.8.2"
     "@snx-v3/ContractError": "workspace:*"
+    "@snx-v3/constants": "workspace:*"
     "@snx-v3/txnReducer": "workspace:*"
     "@snx-v3/useBlockchain": "workspace:*"
     "@snx-v3/useCollateralPriceUpdates": "workspace:*"


### PR DESCRIPTION
- Fixed: rewards claiming popup caches list of claimed rewards and if we change chain popup still shows old values
- Fixed: same problem for synths claiming
- Fixed: precision of synth underlying token when unwrapping (sStataUSDC unwrapping failure)